### PR TITLE
Skill Type Removal

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -8,6 +8,10 @@ module Types
       argument :id, ID, required: true
     end
 
+    field :get_user_by_firebase_i_d, Types::UserType, null: false, description: 'Returns a single user by firebase id' do
+      argument :id, ID, required: true
+    end
+
     field :get_user_pairings, [Types::PairingType], null: false, description: 'Returns a single user pairings by id' do
       argument :id, ID, required: true
     end
@@ -26,6 +30,10 @@ module Types
 
     def get_user(id:)
       User.find(id)
+    end
+
+    def get_user_by_firebase_i_d(id:)
+      User.where(firebase_id: id).first
     end
 
     def get_pairings

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -1,7 +1,7 @@
 module Types
   class QueryType < Types::BaseObject
     field :get_users, [Types::UserType], null: false, description: 'Returns a list of users'
-    field :skills, [Types::SkillType], null: false, description: 'Returns a list of skills'
+
     field :get_pairings, [Types::PairingType], null: false, description: 'Returns all pairings'
 
     field :get_user, Types::UserType, null: false, description: 'Returns a single user by id' do

--- a/app/graphql/types/skill_type.rb
+++ b/app/graphql/types/skill_type.rb
@@ -1,8 +1,0 @@
-module Types
-  class SkillType < Types::BaseObject
-    field :id, ID, null: false
-    field :name, String, null: false
-
-    field :user, Types::UserType, null: false
-  end
-end

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -9,6 +9,7 @@ module Types
     field :email, String, null: false
     field :image, String, null: false
     field :phone_number, String, null: false
+    field :firebase_id, String, null: false
     field :skills, [String], null: true
 
     def skills

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -9,7 +9,12 @@ module Types
     field :email, String, null: false
     field :image, String, null: false
     field :phone_number, String, null: false
+    field :skills, [String], null: true
 
-    field :skills, [Types::SkillType], null: true
+    def skills
+      object.skills.map do |skill|
+        skill.name
+      end
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,5 +8,6 @@ FactoryBot.define do
     email { Faker::Internet.email }
     image { Faker::LoremFlickr.image }
     phone_number { "4233162121" }
+    firebase_id { Faker::Alphanumeric.alphanumeric(number: 28 )}
   end
 end

--- a/spec/graphql/mutations/users/create_users_spec.rb
+++ b/spec/graphql/mutations/users/create_users_spec.rb
@@ -33,32 +33,31 @@ RSpec.describe CreateUser, type: :request do
         mutation {
           user: createUser(
           input: {
-        name: "Samantha"
-        email: "so@gmail.com"
-        image: "https://robohash.org/image"
-        firebaseID: "425tgw2g4w43"
-        mod: "3"
-        program: "BE"
-        phoneNumber: "4231563232"
-        pronouns: "she/her"
-        slack: "rer7891"
-        skills: ["ruby", "rails", "graphql"]
-      }
-    ) {
-      name
-      program
-      mod
-      id
-      image
-      pronouns
-      email
-      slack
-      skills
-        { id }
-    }
-  }
-  GQL
-end
+            name: "Samantha"
+            email: "so@gmail.com"
+            image: "https://robohash.org/image"
+            firebaseID: "425tgw2g4w43"
+            mod: "3"
+            program: "BE"
+            phoneNumber: "4231563232"
+            pronouns: "she/her"
+            slack: "rer7891"
+            skills: ["ruby", "rails", "graphql"]
+          }
+          ) {
+            name
+            program
+            mod
+            id
+            image
+            pronouns
+            email
+            slack
+            skills
+            }
+          }
+        GQL
+      end
+    end
   end
-end
 end

--- a/spec/graphql/queries/pairings/get_single_pairing_spec.rb
+++ b/spec/graphql/queries/pairings/get_single_pairing_spec.rb
@@ -24,9 +24,7 @@ RSpec.describe Types::QueryType do
         program
         id
         pronouns
-        skills {
-                id
-        }
+        skills
         slack
         image
       }
@@ -36,8 +34,8 @@ RSpec.describe Types::QueryType do
       date
       time
       id
-    }
-  }
+        }
+      }
     GQL
   end
 end


### PR DESCRIPTION
### Sidebar Checklist

- [x] Request reviewers
- [x] Assign yourself and other contributors
- [x] Link to project

### Issues Resolved
Resolves #16 

### Problem Addressed
The front end expects to see skills returned as an array of strings rather than an array of skill objects. We also needed a query to find a user by their firebase id.

### Solution Implemented
- Removed the skills_type file all together
- Changed the skills field in the user_type file from [Types::SkillType] to [String] to reflect that skills would be coming back as an array of strings
- Aliased the skills field by writing a method called skills which maps over each skill and grabs its name 
- Created a resolver for finding a user by their firebase id

### Other Notes
