### PR TITLE
Fix back-end issues with module vs. mod

### DIFF
--- a/app/graphql/mutations/users/create_user.rb
+++ b/app/graphql/mutations/users/create_user.rb
@@ -4,7 +4,9 @@ module Mutations
       argument :name, String, required: true
       argument :email, String, required: true
       argument :image, String, required: true
-      argument :mod, String, required: true
+      argument :module, String,
+               required: true,
+               as: :mod
       argument :program, String, required: true
       argument :pronouns, String, required: true
       argument :slack, String, required: true

--- a/app/graphql/mutations/users/update_user.rb
+++ b/app/graphql/mutations/users/update_user.rb
@@ -5,7 +5,7 @@ module Mutations
       argument :name, String, required: false
       argument :email, String, required: false
       argument :image, String, required: false
-      argument :mod, String, required: false
+      argument :module, String, required: false, as: :mod
       argument :program, String, required: false
       argument :pronouns, String, required: false
       argument :slack, String, required: false

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -2,7 +2,7 @@ module Types
   class UserType < Types::BaseObject
     field :id, ID, null: false
     field :name, String, null: false
-    field :mod, String, null: false
+    field :module, String, null: false, method: :mod
     field :program, String, null: false
     field :pronouns, String, null: false
     field :slack, String, null: false

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -2,7 +2,10 @@ module Types
   class UserType < Types::BaseObject
     field :id, ID, null: false
     field :name, String, null: false
-    field :module, String, null: false, resolver_method: :mod
+    field :module, String,
+          null: false,
+          method: :mod,
+          method_conflict_warning: false
     field :program, String, null: false
     field :pronouns, String, null: false
     field :slack, String, null: false

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -2,7 +2,7 @@ module Types
   class UserType < Types::BaseObject
     field :id, ID, null: false
     field :name, String, null: false
-    field :module, String, null: false, method: :mod
+    field :module, String, null: false, resolver_method: :mod
     field :program, String, null: false
     field :pronouns, String, null: false
     field :slack, String, null: false

--- a/spec/graphql/mutations/pairings/deletes_users_pairings_spec.rb
+++ b/spec/graphql/mutations/pairings/deletes_users_pairings_spec.rb
@@ -25,12 +25,14 @@ RSpec.describe DeleteUserPairings, type: :request do
     def query
       <<~GQL
       mutation {
-     deletePairings(
-        	input:{
-            id: "122" } ) {
-        pairer { id }
+        deletePairings(
+          input:{
+            id: "122"
+          }
+        ) {
+          pairer { id }
+        }
       }
-    }
       GQL
     end
 

--- a/spec/graphql/mutations/users/create_users_spec.rb
+++ b/spec/graphql/mutations/users/create_users_spec.rb
@@ -1,33 +1,34 @@
 require 'rails_helper'
+
 module Mutations
   module Users
-RSpec.describe CreateUser, type: :request do
-  describe '.resolve' do
+    RSpec.describe CreateUser, type: :request do
+      describe '.resolve' do
         it 'creates a user' do
           expect(User.count).to eq(0)
           post '/graphql', params: {query: query}
           expect(User.count).to eq(1)
         end
 
-    it 'returns a user' do
+        it 'returns a user' do
+          post '/graphql', params: { query: query }
+          json = JSON.parse(response.body)
+          data = json['data']
+          expect(data['user']['name']).to eq('Samantha')
+          expect(data['user']['program']).to eq('BE')
+          expect(data['user']['module']).to eq('3')
+          expect(data['user']['email']).to eq('so@gmail.com')
+          expect(data['user']['pronouns']).to eq('she/her')
+        end
 
-      post '/graphql', params: { query: query }
-      json = JSON.parse(response.body)
-      data = json['data']
-         expect(data['user']['name']).to eq('Samantha')
-         expect(data['user']['program']).to eq('BE')
-         expect(data['user']['mod']).to eq('3')
-         expect(data['user']['email']).to eq('so@gmail.com')
-         expect(data['user']['pronouns']).to eq('she/her')
-    end
+        it 'returns skills for a user' do
+          post '/graphql', params: { query: query }
+          user = User.last
+          skills = user.skills.map { |skill| skill.name }
+          expect(skills).to eq(["ruby", "rails", "graphql"])
+        end
+      end
 
-    it  'returns skills for a user' do
-      post '/graphql', params: { query: query }
-      user = User.last
-      skills = user.skills.map { |skill| skill.name }
-      expect(skills).to eq(["ruby", "rails", "graphql"])
-    end
-  end
       def query
         <<~GQL
         mutation {
@@ -37,7 +38,7 @@ RSpec.describe CreateUser, type: :request do
             email: "so@gmail.com"
             image: "https://robohash.org/image"
             firebaseID: "425tgw2g4w43"
-            mod: "3"
+            module: "3"
             program: "BE"
             phoneNumber: "4231563232"
             pronouns: "she/her"
@@ -47,7 +48,7 @@ RSpec.describe CreateUser, type: :request do
           ) {
             name
             program
-            mod
+            module
             id
             image
             pronouns

--- a/spec/graphql/mutations/users/update_user_spec.rb
+++ b/spec/graphql/mutations/users/update_user_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe UpdateUser, type: :request do
 
       expect(data['user']['name']).to eq('Carl Crockett')
       expect(data['user']['program']).to eq('BE')
-      expect(data['user']['mod']).to eq('2')
+      expect(data['user']['module']).to eq('2')
       expect(data['user']['email']).to eq('cap@gmail.com')
       expect(data['user']['pronouns']).to eq('she/her')
     end
@@ -52,7 +52,7 @@ RSpec.describe UpdateUser, type: :request do
       expect(bob.skills).to eq([skill_1, skill_2, skill_3])
 
       post '/graphql', params: { query: query_2 }
-      
+
       result = JSON.parse(response.body)
       skills = result["data"]["user"]["skills"]
 
@@ -69,7 +69,7 @@ RSpec.describe UpdateUser, type: :request do
             id: "10"
             name: "Carl Crockett"
             email: "cap@gmail.com"
-            mod: "2"
+            module: "2"
             program: "BE"
             pronouns: "she/her"
             slack: "capleugh"
@@ -78,7 +78,7 @@ RSpec.describe UpdateUser, type: :request do
           ) {
             name
             program
-            mod
+            module
             id
             image
             pronouns
@@ -98,7 +98,7 @@ RSpec.describe UpdateUser, type: :request do
             id: "11"
             name: "Carl Crockett"
             email: "cap@gmail.com"
-            mod: "2"
+            module: "2"
             program: "BE"
             pronouns: "she/her"
             slack: "capleugh"
@@ -107,7 +107,7 @@ RSpec.describe UpdateUser, type: :request do
           ) {
             name
             program
-            mod
+            module
             id
             image
             pronouns

--- a/spec/graphql/queries/pairings/get_single_pairing_spec.rb
+++ b/spec/graphql/queries/pairings/get_single_pairing_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Types::QueryType do
     getPairing(id: "1") {
       pairer {
         name
-        mod
+        module
         program
         id
         pronouns

--- a/spec/graphql/queries/users/get_single_user_spec.rb
+++ b/spec/graphql/queries/users/get_single_user_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Types::QueryType do
       result = PairedBeSchema.execute(query).as_json
 
       expect(result["data"]["getUser"]["name"]).to eq("Cate Blanchett")
-      expect(result["data"]["getUser"]["mod"]).to eq("3")
+      expect(result["data"]["getUser"]["module"]).to eq("3")
       expect(result["data"]["getUser"]["program"]).to eq("BE")
     end
   end
@@ -20,7 +20,7 @@ RSpec.describe Types::QueryType do
       getUser(id: "1") {
         name
         program
-        mod
+        module
         id
         image
       }

--- a/spec/graphql/queries/users/get_user_by_firebase_query_spec.rb
+++ b/spec/graphql/queries/users/get_user_by_firebase_query_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Types::QueryType do
 
       expect(result["data"]["getUserByFirebaseID"]["name"]).to eq("Ralph")
       expect(result["data"]["getUserByFirebaseID"]["program"]).to eq("BE")
-      expect(result["data"]["getUserByFirebaseID"]["mod"]).to eq("3")
+      expect(result["data"]["getUserByFirebaseID"]["module"]).to eq("3")
       expect(result["data"]["getUserByFirebaseID"]["id"]).to eq("75")
       expect(result["data"]["getUserByFirebaseID"]["image"]).to eq("https://i.ytimg.com/vi/ndsaoMFz9J4/maxresdefault.jpg")
       expect(result["data"]["getUserByFirebaseID"]["pronouns"]).to eq("he/him")
@@ -29,7 +29,7 @@ RSpec.describe Types::QueryType do
       	getUserByFirebaseID(id: "er561v3h0si34bu56m1l2e34v7ax") {
           name
           program
-          mod
+          module
           id
           image
           pronouns

--- a/spec/graphql/queries/users/get_user_pairings_spec.rb
+++ b/spec/graphql/queries/users/get_user_pairings_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Types::QueryType do
       {
        pairer {
          name
-         mod
+         module
          program
          id
          pronouns
@@ -33,7 +33,7 @@ RSpec.describe Types::QueryType do
        }
        pairee {
          name
-         mod
+         module
          program
          pronouns
          slack

--- a/spec/graphql/queries/users/get_users_spec.rb
+++ b/spec/graphql/queries/users/get_users_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Types::QueryType do
 
       users = User.all
       expect(result.dig("data", "getUsers")).to match_array(
-      users.map { |user| {"mod" => user.mod, "name" => user.name, "program" => user.program} })
+      users.map { |user| {"module" => user.mod, "name" => user.name, "program" => user.program} })
     end
   end
 
@@ -22,7 +22,7 @@ RSpec.describe Types::QueryType do
       getUsers {
         name
         program
-        mod
+        module
         }
     }
     GQL


### PR DESCRIPTION
### Sidebar Checklist

- [x] Request reviewers
- [x] Assign yourself and other contributors
- [x] Link to project

### Issues Resolved
Resolves #68 

### Problem Addressed
Because the FE queries referred to the User's current mod as `module` but that is a reserved keyword in Rails, the BE database (and thus queries) referred to that attribute as `mod`, creating a disconnect between BE and FE. Changing all the references in one or the other repo would be a pain.

### Solution Implemented
Instead of changing all the references, I researched ways to override which model method is called for a particular GraphQL field, and found one; now, when GraphQL looks for a User's `module`, it runs the `mod` attr_reader method to get that user's mod attribute.

A similar step was taken in the `createUser` mutation and will need to be taken in future mutations; the option `as: :mod` will need to be added to any `module` arguments.

### Other Notes
I opened an issue on the `graphql-ruby` repo to report an issue I encountered while trying to fix this, which can be found [here](https://github.com/rmosolgo/graphql-ruby/issues/2775).
