### PR TITLE
Add Heroku deployment and bundler caching to TravisCI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 language: ruby
+cache: bundler
 rvm:
 - 2.5.3
-
 services:
-  - postgresql
-
+- postgresql
 before_install:
-  - gem install bundler
-
+- gem install bundler
 before_script:
-  - psql -c 'create database paired_be_test;' -U postgres
+- psql -c 'create database paired_be_test;' -U postgres
+deploy:
+  provider: heroku
+  api_key:
+    secure: estLSfkT0B1opvyqUdyFia/cRaq/uqll5JKUNUwC7UyweGMlpogUZmYia4xV36KwllM8jKrF1YwhdrE4AV6XdcB2VEJSk4rRhaQKkZG/uNdyq4XxsZPACHYCd/DeFhRcO37m7GM/TKgwP1BfV7DEhalhYCBpyHHcORjht1ayqWbKFLuJL3kSrYHDqETapYztowokwwiF2l+iGNPj4q5jPlM3guOSAFCD1vQTGopAHPKWUkgrUJ4lTmal0Ur6hcronD2VkwB41vcFVhfM1pw0fhbfmKwXT1loqI16czMf9w7GQoC4V+jybk0YV7mkgNiAJl7HwtrR9wlTziX419KFkKXBr1zEf6ZaCivincS1A4zZwhz+/SzNDGYOeWPAjNE1wRbrS1Cg9gxdPZbbzn8vAc26EcYoAHpf/S0uXHdxrWq9TAlrGy2tXLLVZeQ7iU8aSYwh9fgwV1yVAGobbRVZMedOB5CjgFvdC/R5x3GaK1vb1ocIPyrF6V+b00RtPtSzgNRI3H/lA0fSAQns2bWe+dWszF41FQFpre4+gofNP4X8JLUH1wA27XridpyhvLpyfrSwHxuSQ/ImWy2B+9+FlPkxmWKzsTDON8vVSlZymUUp3omXbm5fHNr8uAmLTDXOgrD1GXE83F61OpnSz92dZsgXJsS0OLU+9weJq5krG38=
+  on:
+    condition: type = push AND branch = master


### PR DESCRIPTION
### Sidebar Checklist

- [x] Request reviewers
- [x] Assign yourself and other contributors
- [x] Link to project

### Issues Resolved
Resolves #63 

### Problem Addressed
We did not have our back-end repo deployed to Heroku nor configured to be automatically deployed upon successful pushes to master.

### Solution Implemented
Set up Heroku deployment and added configuration to TravisCI config file to automatically deploy using hashed API key provided by Heroku upon the condition of a push to master.

### Other Notes
Also added bundler caching so that the gems don't need to be installed every time.