### PR TITLE
Permit Firebase requests

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -52,5 +52,5 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   # Rack-CORS allowed origin in this environment
-  config.allowed_cors_origins = ["http://locahost:3000"]
+  config.allowed_cors_origins = ["http://localhost:3000"]
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -50,4 +50,7 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # Rack-CORS allowed origin in this environment
+  config.allowed_cors_origins = ["http://locahost:3000"]
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -113,4 +113,7 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+
+  # Rack-CORS allowed origin in this environment
+  config.allowed_cors_origins = ["http://landslide-57f9a.firebaseapp.com", "http://paired-turing.firebaseapp.com"]
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,4 +45,7 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
+
+  # Rack-CORS allowed origin in this environment
+  config.allowed_cors_origins = ["http://locahost:3000"]
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -47,5 +47,5 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   # Rack-CORS allowed origin in this environment
-  config.allowed_cors_origins = ["http://locahost:3000"]
+  config.allowed_cors_origins = ["http://localhost:3000"]
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins 'localhost:3000'
+    origins Rails.application.config.allowed_cors_origins
 
     resource '*',
       headers: :any,


### PR DESCRIPTION
### Sidebar Checklist

- [x] Request reviewers
- [x] Assign yourself and other contributors
- [x] Link to project

### Issues Resolved
Resolves #83 

### Problem Addressed
The `rack-cors` gem was originally configured to only allow requests from localhost:3000, so the deployed Firebase app was unable to fetch data from the GraphQL endpoint.

### Solution Implemented
Set config variable in the three different environment files passing different arrays of allowed origin URLs to the cors.rb file, so that `localhost:3000` is permitted in Development and Test, and both the new and old Firebase apps are permitted in Production. Credit to [this StackOverflow thread](https://stackoverflow.com/questions/49985642/rails-5-1-cors-how-to-set-different-origins-for-different-environments).

### Other Notes
Unlike the FE change to the utils.js file, this won't require you to change it manually. If we can figure out a way to make the React code do this, that would be swell.