### PR TITLE
Update rack_cors config to expect https protocol

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -115,5 +115,5 @@ Rails.application.configure do
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 
   # Rack-CORS allowed origin in this environment
-  config.allowed_cors_origins = ["http://landslide-57f9a.firebaseapp.com", "http://paired-turing.firebaseapp.com"]
+  config.allowed_cors_origins = ["https://landslide-57f9a.firebaseapp.com", "https://paired-turing.firebaseapp.com"]
 end


### PR DESCRIPTION
### Sidebar Checklist

- [x] Request reviewers
- [x] Assign yourself and other contributors
- [x] Link to project

### Issues Resolved
Resolves ongoing problem with #66 

### Problem Addressed
Previous change to rack_cors provided `http://` addresses, but the actual GraphQL API calls come from `https://` addresses. 

### Solution Implemented
Changed from http to https in the origins for production environment.

### Other Notes
