### PR TITLE
Change phoneNumber and pronouns fields to be nullable

### DIFF
--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -7,11 +7,11 @@ module Types
           method: :mod,
           method_conflict_warning: false
     field :program, String, null: false
-    field :pronouns, String, null: false
+    field :pronouns, String, null: true
     field :slack, String, null: false
     field :email, String, null: false
     field :image, String, null: false
-    field :phone_number, String, null: false
+    field :phone_number, String, null: true
     field :firebase_id, String, null: false
 
     field :skills, [String], null: true


### PR DESCRIPTION
### Sidebar Checklist

- [x] Request reviewers
- [x] Assign yourself and other contributors
- [x] Link to project

### Issues Resolved
Resolves #87 

### Problem Addressed
After logging into the front end, the user data would not be loaded and this error was loaded into Redux state:
```
"Cannot return null for non-nullable field User.phoneNumber"
```
And none of the menu components would be displayed.

### Solution Implemented
Changed `phoneNumber` (and `pronouns`) fields to be nullable (`null: true`) in the `user_type` file.

### Other Notes
