### PR TITLE
Cancel notification fix

### DIFF
--- a/app/graphql/mutations/pairings/cancel_mentee_pairing.rb
+++ b/app/graphql/mutations/pairings/cancel_mentee_pairing.rb
@@ -24,7 +24,7 @@ module Mutations
       def notifications(pairing)
         message = create_message(pairing)
         contact_info = pairing.pairee_contact_info
-        NotificationsWorker.perform_later(contact_info, message)
+        NotificationsWorker.perform_later(contact_info, message, :cancel_message)
       end
     end
   end

--- a/app/graphql/mutations/pairings/cancel_mentee_pairing.rb
+++ b/app/graphql/mutations/pairings/cancel_mentee_pairing.rb
@@ -1,3 +1,4 @@
+# Mentor cancels pairing created by mentee
 module Mutations
   module Pairings
     class CancelMenteePairing < ::Mutations::BaseMutation
@@ -14,7 +15,7 @@ module Mutations
       private
 
       def create_message(pairing)
-        name = pairing.pairee_name
+        name = pairing.pairer_name
         date = pairing.date
         time = pairing.time
         MessageGenerator.new.cancel_notification(name, date, time)
@@ -22,7 +23,7 @@ module Mutations
 
       def notifications(pairing)
         message = create_message(pairing)
-        contact_info = pairing.pairer_contact_info
+        contact_info = pairing.pairee_contact_info
         NotificationsWorker.perform_later(contact_info, message)
       end
     end

--- a/app/graphql/mutations/pairings/cancel_mentee_pairing.rb
+++ b/app/graphql/mutations/pairings/cancel_mentee_pairing.rb
@@ -1,4 +1,4 @@
-# Mentor cancels pairing created by mentee
+# Mentor cancels pairing created by mentee, notifying mentee
 module Mutations
   module Pairings
     class CancelMenteePairing < ::Mutations::BaseMutation

--- a/app/graphql/mutations/pairings/cancel_mentor_pairing.rb
+++ b/app/graphql/mutations/pairings/cancel_mentor_pairing.rb
@@ -1,4 +1,4 @@
-
+# Mentee cancels pairing, notifying mentor
 module Mutations
   module Pairings
     class CancelMentorPairing < ::Mutations::BaseMutation
@@ -15,7 +15,7 @@ module Mutations
       private
 
       def create_message(pairing)
-        name = pairing.pairer_name
+        name = pairing.pairee_name
         date = pairing.date
         time = pairing.time
         MessageGenerator.new.cancel_notification(name, date, time)
@@ -23,7 +23,7 @@ module Mutations
 
       def notifications(pairing)
         message = create_message(pairing)
-        contact_info = pairing.pairee_contact_info
+        contact_info = pairing.pairer_contact_info
         NotificationsWorker.perform_later(contact_info, message)
       end
     end

--- a/app/graphql/mutations/pairings/cancel_mentor_pairing.rb
+++ b/app/graphql/mutations/pairings/cancel_mentor_pairing.rb
@@ -24,7 +24,7 @@ module Mutations
       def notifications(pairing)
         message = create_message(pairing)
         contact_info = pairing.pairer_contact_info
-        NotificationsWorker.perform_later(contact_info, message)
+        NotificationsWorker.perform_later(contact_info, message, :cancel_message)
       end
     end
   end

--- a/app/mailers/appointment_notif.rb
+++ b/app/mailers/appointment_notif.rb
@@ -8,4 +8,9 @@ class AppointmentNotif < ApplicationMailer
     @message = message
     mail(to: address, subject: "You have a pairing today!")
   end
+
+  def cancel_message(address, message)
+    @message = message
+    mail(to: address, subject: "Your pairing has been canceled. :(")
+  end
 end

--- a/app/views/appointment_notif/cancel_message.html.erb
+++ b/app/views/appointment_notif/cancel_message.html.erb
@@ -1,0 +1,3 @@
+<h1 style="font-family: 'Oswald'; text-color:#525b86;" width="250">Paired</h1>
+<%= @message %>
+<p>Sincerely, <br>The Paired Team</p>

--- a/app/views/appointment_notif/cancel_message.txt.erb
+++ b/app/views/appointment_notif/cancel_message.txt.erb
@@ -1,0 +1,5 @@
+Paired
+<%= @message %>
+Sincerely,
+
+The Paired Team

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,12 +1,17 @@
-desc "Import data from jsom files"
+# Import JSON data exported from old BE's MongoDB from command line.
+# Usage: `rake import users.json pairings.json` if files are in root dir.
+
+desc "Import data from json files"
 task :import => [:environment] do
 
   Skill.destroy_all
   Pairing.destroy_all
   User.destroy_all
 
-  #if you need to add oid to the user table use the following line
-  #ActiveRecord::Migration.add_column :users, :oid, :string
+  # If you need to add oid to the user table use the following line.
+  # Does not work consistently; might need to run task once with below
+  # uncommented, then run again with line commented.
+  # ActiveRecord::Migration.add_column :users, :oid, :string
 
   File.open(ARGV[1]).each do |line|
     user_data = JSON.parse(line)
@@ -51,6 +56,6 @@ task :import => [:environment] do
                    )
   end
 
-  #Assocaited migration to remove oid from users table
-  #ActiveRecord::Migration.remove_column :users, :oid, :string
+  # Associated migration to remove oid from users table
+  ActiveRecord::Migration.remove_column :users, :oid, :string
 end


### PR DESCRIPTION
### Sidebar Checklist

- [x] Request reviewers
- [x] Assign yourself and other contributors
- [x] Link to project

### Issues Resolved
Resolves immediate problem with cancelation notifications not being sent due to argument error.

### Problem Addressed
When attempting to send cancelation notification, Heroku server was reporting error with number of arguments passed to NotificationWorker, and the names and addressee of the message attempted to be sent were backwards from what was intended.

### Solution Implemented
Corrected pairee/pairer reversal, updated cancelation GraphQL mutations to utilize changes to NotificationWorker arguments, and created mailer for cancelation email notification.

### Other Notes
Need to write tests for all of this to prevent future occurances.
