### PR TITLE
Add actual IP address of HTTP request from front-end and paired.tech

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -115,5 +115,8 @@ Rails.application.configure do
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 
   # Rack-CORS allowed origin in this environment
-  config.allowed_cors_origins = ["https://landslide-57f9a.firebaseapp.com", "https://paired-turing.firebaseapp.com"]
+  config.allowed_cors_origins = ["https://landslide-57f9a.firebaseapp.com",
+                                 "https://paired-turing.firebaseapp.com",
+                                 "https://www.paired.tech",
+                                 "67.166.26.146"]
 end


### PR DESCRIPTION
### Sidebar Checklist

- [x] Request reviewers
- [x] Assign yourself and other contributors
- [x] Link to project

### Problem Addressed
Resolves immediate issue with front-end unable to fetch because of CORS settings (presumably).

### Solution Implemented
Added `https://www.paired.tech` and the IP address which the front-end request came from, `67.166.26.146`, to list of allowed CORS origin points.

### Other Notes
