### PR TITLE
Updates cancel pairings mutations to have notes set to nil

### DIFF
--- a/app/graphql/mutations/pairings/cancel_mentee_pairing.rb
+++ b/app/graphql/mutations/pairings/cancel_mentee_pairing.rb
@@ -7,7 +7,7 @@ module Mutations
       def resolve(attributes)
         pairing = Pairing.find(attributes[:id])
         notifications(pairing)
-        pairing.update(pairee_id: nil)
+        pairing.update(pairee_id: nil, notes: nil)
         pairing
       end
 

--- a/app/graphql/mutations/pairings/cancel_mentor_pairing.rb
+++ b/app/graphql/mutations/pairings/cancel_mentor_pairing.rb
@@ -8,7 +8,7 @@ module Mutations
       def resolve(attributes)
         pairing = Pairing.find(attributes[:id])
         notifications(pairing)
-        pairing.update(pairee_id: nil)
+        pairing.update(pairee_id: nil, notes: nil)
         pairing
       end
 

--- a/spec/graphql/mutations/pairings/cancel_mentee_pairing_spec.rb
+++ b/spec/graphql/mutations/pairings/cancel_mentee_pairing_spec.rb
@@ -29,6 +29,12 @@ module Mutations
         expect(data['cancelMenteePairing']['pairee']).to eq(nil)
         expect(data['cancelMenteePairing']['pairer']['name']).to eq(@user.name)
       end
+
+      it 'removes time and notes from pairing after cancellation' do
+        post '/graphql', params: { query: query }
+        json = JSON.parse(response.body)
+        expect(@pairing.notes).to eq(nil)
+      end
     end
 
       def query

--- a/spec/graphql/mutations/pairings/cancel_mentor_pairing_spec.rb
+++ b/spec/graphql/mutations/pairings/cancel_mentor_pairing_spec.rb
@@ -28,6 +28,11 @@ RSpec.describe CancelMentorPairing, type: :request do
       expect(data['cancelMentorPairing']['pairee']).to eq(nil)
       expect(data['cancelMentorPairing']['pairer']["name"]).to eq(@user.name)
     end
+    it 'removes time and notes from pairing after cancellation' do
+      post '/graphql', params: { query: query }
+      json = JSON.parse(response.body)
+      expect(@pairing.notes).to eq(nil)
+    end
   end
     def query
       <<~GQL


### PR DESCRIPTION
### Sidebar Checklist

- [x] Request reviewers
- [x] Assign yourself and other contributors
- [x] Link to project

### Issues Resolved
Resolves # I don't think an issue was made for this.
### Problem Addressed
Once a booking was cancelled the notes attribute was not set to nil retaining any notes from the old booking. 
### Solution Implemented
In the cancel pairings mutations added notes: nil to the update. 
### Other Notes
Updated testing as well to check for notes set to nil. 