### PR TITLE
Change Sendgrid auth method to API key

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,16 +83,17 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.action_mailer.delivery_method = :smtp
+  config.action_mailer.default_url_options = { host: "http://paired-be.herokuapp.com" }
   config.action_mailer.perform_deliveries = true
   config.action_mailer.smtp_settings = {
-   :user_name => ENV['SENDGRID_USERNAME'],
-   :password => ENV['SENDGRID_PASSWORD'],
-   :domain => 'yourdomain.com',
+   :user_name => 'apikey',
+   :password => ENV['SENDGRID_API_KEY'],
+   :domain => 'paired-be.herokuapp.com',
    :address => 'smtp.sendgrid.net',
    :port => 587,
    :authentication => :plain,
-   :enable_starttls_auto => true
  }
+
   # Inserts middleware to perform automatic connection switching.
   # The `database_selector` hash is used to pass options to the DatabaseSelector
   # middleware. The `delay` is used to determine how long to wait after a write


### PR DESCRIPTION
### Sidebar Checklist

- [x] Request reviewers
- [x] Assign yourself and other contributors
- [x] Link to project

### Issues Resolved
Resolves [Issue #99 on FE repo](https://github.com/hillstew/paired-fe/issues/99)

### Problem Addressed
SendGrid authentication was originally configured to go through a personal account, using a username and password entered as environment variables on Heroku, and that personal account's password was reset at an unknown time in the past week+. Email notifications were not being sent.

### Solution Implemented
Reconfigured SendGrid authentication to utilize an API key associated with a SendGrid account connected to the Heroku BE repo through an "add-on" rather than a personal account.

### Other Notes
We created some issues on the in-progress staging repo for the rock-and-pebble feature which will help with error monitoring and debugging in the future so we can be alerted sooner in cases like these.